### PR TITLE
fix: return app versions ordered by id

### DIFF
--- a/src/api/versions.ts
+++ b/src/api/versions.ts
@@ -36,7 +36,8 @@ export const getActiveAppVersions = async (supabase: SupabaseClient, appid: stri
     .select()
     .eq('app_id', appid)
     .eq('user_id', userId)
-    .eq('deleted', false);
+    .eq('deleted', false)
+    .order('id');
 
   if (vError) {
     program.error(`App ${appid} not found in database ${formatError(vError)} `);


### PR DESCRIPTION
Apparently supabase does not by default order the output, the cleanup command depends on this ordering to properly do it's work and delete the correct previous versions.

This makes sure the getActiveAppVersions is ordered by id, so last inserted (most recent) will be returned last.